### PR TITLE
feat: npm distribution via @ai-kit/core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+dist/
+kit/
+.state/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,41 @@ curl -fsSL "https://github.com/krajh/ai-kit/releases/latest/download/install" | 
   bash -s -- --command update
 ```
 
+### npm (Node.js projects)
+
+If your project uses Node.js, you can install ai-kit as a dev dependency:
+
+```bash
+npm install --save-dev @ai-kit/core
+```
+
+This automatically symlinks the kit files into `~/.config/opencode/`:
+
+- `opencode.json`, `AGENTS.md`, `agents/`, `skills/`, `protocols/`, `plugins/`
+
+Each symlink points into `node_modules/@ai-kit/core/kit/`, so the kit stays in sync with your pinned version.
+
+**Uninstalling** (`npm uninstall @ai-kit/core`) cleanly removes only its own symlinks — any user-created files are preserved.
+
+#### Personalisation safety (npm)
+
+If you've customised a file that ai-kit also manages (e.g. `~/.config/opencode/opencode.json`), the postinstall script will:
+
+1. Detect the user-modified file
+2. Back it up as `<filename>.user-backup`
+3. Replace it with the kit's symlink
+
+This ensures you never silently lose your customisations.
+
+#### When to use npm vs curl | bash
+
+| Method         | Best for                                              |
+| -------------- | ----------------------------------------------------- |
+| `npm install`  | Node.js projects, version pinning via `package.json`  |
+| `curl \| bash` | System-wide install, non-Node projects, CI pipelines  |
+
+> **Note:** The npm distribution does not include the auto-updater plugin. Version updates happen through normal `npm update` workflows.
+
 ### Manual (download installer)
 
 1. **Pick a release**: <https://github.com/krajh/ai-kit/releases>

--- a/package.json
+++ b/package.json
@@ -1,9 +1,34 @@
 {
-  "name": "ai-kit",
-  "private": true,
+  "name": "@ai-kit/core",
+  "version": "0.4.0",
+  "description": "OpenCode configuration kit — agents, skills, protocols, and plugins for AI-assisted development",
+  "type": "module",
   "scripts": {
     "test": "bun test",
-    "fmt": "bunx prettier --check --ignore-unknown ."
+    "fmt": "bunx prettier --check --ignore-unknown .",
+    "build": "bun build src/postinstall.ts --outdir dist --target node && bun build src/preuninstall.ts --outdir dist --target node",
+    "build-kit": "bun src/build-kit.ts",
+    "prepublishOnly": "bun run build-kit && bun run build",
+    "postinstall": "node dist/postinstall.js",
+    "preuninstall": "node dist/preuninstall.js"
+  },
+  "files": [
+    "dist/",
+    "kit/",
+    "README.md",
+    "LICENSE"
+  ],
+  "keywords": [
+    "opencode",
+    "ai-kit",
+    "agents",
+    "skills",
+    "plugins"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/krajh/ai-kit.git"
   },
   "dependencies": {
     "@opencode-ai/plugin": "1.1.41"

--- a/plugins/ai-kit-updater.ts
+++ b/plugins/ai-kit-updater.ts
@@ -654,7 +654,24 @@ async function checkAndStageUpdate(): Promise<void> {
   await writeState(state);
 }
 
+const NPM_MARKER = join(OPENCODE_HOME, ".ai-kit-npm");
+
+function isNpmDistributed(): boolean {
+  try {
+    const { statSync } = require("node:fs");
+    statSync(NPM_MARKER);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 const AiKitUpdaterPlugin: Plugin = async () => {
+  if (isNpmDistributed()) {
+    // npm handles versioning — updater is a no-op
+    return {};
+  }
+
   try {
     await applyStagedUpdateOnStartup();
   } catch {

--- a/src/build-kit.ts
+++ b/src/build-kit.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env bun
+
+/**
+ * Assembles the kit/ directory from repo source files.
+ * Run before `npm publish` to populate the distribution payload.
+ *
+ * Usage: bun run build-kit
+ */
+
+import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dirname, "..");
+const KIT_DIR = join(ROOT, "kit");
+
+const KIT_ITEMS = [
+  { src: "agents", type: "dir" },
+  { src: "skills", type: "dir" },
+  { src: "protocols", type: "dir" },
+  { src: "plugins", type: "dir" },
+  { src: "AGENTS.md", type: "file" },
+  { src: "opencode.json", type: "file" },
+] as const;
+
+function main(): void {
+  console.log("[kit-builder] Assembling kit/ from repo sources\n");
+
+  if (existsSync(KIT_DIR)) {
+    rmSync(KIT_DIR, { recursive: true });
+  }
+  mkdirSync(KIT_DIR, { recursive: true });
+
+  let copied = 0;
+  let skipped = 0;
+
+  for (const item of KIT_ITEMS) {
+    const srcPath = join(ROOT, item.src);
+
+    if (!existsSync(srcPath)) {
+      console.log(`  [!] Skipped: ${item.src} (not found)`);
+      skipped++;
+      continue;
+    }
+
+    const destPath = join(KIT_DIR, item.src);
+
+    if (item.type === "dir") {
+      cpSync(srcPath, destPath, { recursive: true });
+    } else {
+      cpSync(srcPath, destPath);
+    }
+
+    console.log(`  [OK] ${item.src}`);
+    copied++;
+  }
+
+  console.log(
+    `\n[kit-builder] Done: ${copied} items copied, ${skipped} skipped`
+  );
+}
+
+main();

--- a/src/postinstall.ts
+++ b/src/postinstall.ts
@@ -1,0 +1,287 @@
+#!/usr/bin/env node
+
+/**
+ * @ai-kit/core postinstall
+ *
+ * Creates symlinks from ~/.config/opencode/ → this package's kit/ directory.
+ * Handles personalisation safety: detects user-modified files and preserves them.
+ *
+ * Symlinked items: opencode.json, AGENTS.md, agents/, skills/, protocols/, plugins/
+ */
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export const KIT_LINK_ITEMS = [
+  "opencode.json",
+  "AGENTS.md",
+  "agents",
+  "skills",
+  "protocols",
+  "plugins",
+] as const;
+
+export const MARKER_FILE = ".ai-kit-npm";
+export const CHECKSUMS_FILE = ".ai-kit-checksums";
+export const BACKUP_SUFFIX = ".user-backup";
+
+export function getOpenCodeHome(): string {
+  return (
+    process.env.OPENCODE_HOME ?? join(homedir(), ".config", "opencode")
+  );
+}
+
+export function getKitDir(): string {
+  return resolve(join(__dirname, "..", "kit"));
+}
+
+export function sha256(filePath: string): string {
+  const content = readFileSync(filePath);
+  return createHash("sha256").update(content).digest("hex");
+}
+
+export function isSymlinkToKit(linkPath: string, kitDir: string): boolean {
+  try {
+    if (!lstatSync(linkPath).isSymbolicLink()) return false;
+    const target = readlinkSync(linkPath);
+    return resolve(dirname(linkPath), target).startsWith(kitDir);
+  } catch {
+    return false;
+  }
+}
+
+export function isOurSymlink(linkPath: string): boolean {
+  try {
+    if (!lstatSync(linkPath).isSymbolicLink()) return false;
+    const target = readlinkSync(linkPath);
+    return target.includes("@ai-kit") || target.includes("ai-kit");
+  } catch {
+    return false;
+  }
+}
+
+export function walkFiles(dir: string): string[] {
+  const results: string[] = [];
+  if (!existsSync(dir)) return results;
+
+  const stat = statSync(dir);
+  if (stat.isFile()) return [dir];
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkFiles(fullPath));
+    } else if (entry.isFile()) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+export function computeChecksums(kitDir: string): Record<string, string> {
+  const checksums: Record<string, string> = {};
+  for (const item of KIT_LINK_ITEMS) {
+    const itemPath = join(kitDir, item);
+    if (!existsSync(itemPath)) continue;
+
+    const files = walkFiles(itemPath);
+    for (const file of files) {
+      const relPath = file.slice(kitDir.length + 1);
+      checksums[relPath] = sha256(file);
+    }
+  }
+  return checksums;
+}
+
+export function readStoredChecksums(
+  ocHome: string
+): Record<string, string> | null {
+  const checksumPath = join(ocHome, CHECKSUMS_FILE);
+  if (!existsSync(checksumPath)) return null;
+
+  try {
+    return JSON.parse(readFileSync(checksumPath, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+export function writeChecksums(
+  ocHome: string,
+  checksums: Record<string, string>
+): void {
+  writeFileSync(
+    join(ocHome, CHECKSUMS_FILE),
+    JSON.stringify(checksums, null, 2) + "\n",
+    "utf-8"
+  );
+}
+
+export function backupUserFile(filePath: string): void {
+  const backupPath = filePath + BACKUP_SUFFIX;
+  console.log(`  [!] Backing up user-modified file: ${filePath} → ${backupPath}`);
+  renameSync(filePath, backupPath);
+}
+
+export function detectUserModifications(
+  ocHome: string,
+  storedChecksums: Record<string, string>
+): string[] {
+  const modified: string[] = [];
+
+  for (const [relPath, storedHash] of Object.entries(storedChecksums)) {
+    const filePath = join(ocHome, relPath);
+    if (!existsSync(filePath)) continue;
+    if (lstatSync(filePath).isSymbolicLink()) continue;
+
+    try {
+      const currentHash = sha256(filePath);
+      if (currentHash !== storedHash) {
+        modified.push(relPath);
+      }
+    } catch {
+      // skip unreadable files
+    }
+  }
+
+  return modified;
+}
+
+export function safeCreateLink(
+  kitDir: string,
+  ocHome: string,
+  item: string
+): void {
+  const source = join(kitDir, item);
+  const target = join(ocHome, item);
+
+  if (!existsSync(source)) {
+    console.log(`  [!] Kit item not found, skipping: ${item}`);
+    return;
+  }
+
+  try {
+    const targetStat = lstatSync(target);
+    const targetExists = true;
+
+    if (targetStat.isSymbolicLink()) {
+      if (isOurSymlink(target)) {
+        unlinkSync(target);
+      } else {
+        console.log(`  [!] ${item}: foreign symlink exists, replacing`);
+        unlinkSync(target);
+      }
+    } else {
+      backupUserFile(target);
+    }
+  } catch (err: any) {
+    if (err.code !== "ENOENT") throw err;
+    // target doesn't exist, proceed
+  }
+
+  symlinkSync(source, target);
+  console.log(`  [OK] ${item} → ${source}`);
+}
+
+export function writeMarker(ocHome: string, kitDir: string): void {
+  const marker = {
+    version: getPackageVersion(),
+    kitDir,
+    installedAt: new Date().toISOString(),
+    items: [...KIT_LINK_ITEMS],
+  };
+
+  writeFileSync(
+    join(ocHome, MARKER_FILE),
+    JSON.stringify(marker, null, 2) + "\n",
+    "utf-8"
+  );
+}
+
+export function getPackageVersion(): string {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(join(__dirname, "..", "package.json"), "utf-8")
+    );
+    return pkg.version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+export function main(): void {
+  const ocHome = getOpenCodeHome();
+  const kitDir = getKitDir();
+
+  console.log(`\n@ai-kit/core postinstall`);
+  console.log(`  target: ${ocHome}`);
+  console.log(`  source: ${kitDir}`);
+
+  if (!existsSync(kitDir)) {
+    console.log(`  [X] Kit directory not found: ${kitDir}`);
+    console.log(`  Skipping postinstall (development mode?)`);
+    return;
+  }
+
+  mkdirSync(ocHome, { recursive: true });
+
+  // Detect user modifications before overwriting
+  const storedChecksums = readStoredChecksums(ocHome);
+  if (storedChecksums) {
+    const modified = detectUserModifications(ocHome, storedChecksums);
+    if (modified.length > 0) {
+      console.log(`\n  User-modified files detected:`);
+      for (const m of modified) {
+        console.log(`    - ${m}`);
+      }
+      console.log(`  These will be backed up with ${BACKUP_SUFFIX} suffix.\n`);
+    }
+  }
+
+  // Create symlinks
+  for (const item of KIT_LINK_ITEMS) {
+    safeCreateLink(kitDir, ocHome, item);
+  }
+
+  // Write checksums for next update
+  const newChecksums = computeChecksums(kitDir);
+  writeChecksums(ocHome, newChecksums);
+
+  // Write marker so the updater plugin knows we're npm-distributed
+  writeMarker(ocHome, kitDir);
+
+  console.log(`\n  [OK] @ai-kit/core v${getPackageVersion()} installed successfully\n`);
+}
+
+// Only auto-execute when run directly (not when imported for testing)
+const isDirectExecution =
+  typeof process !== "undefined" &&
+  process.argv[1] &&
+  (process.argv[1].endsWith("postinstall.js") ||
+    process.argv[1].endsWith("postinstall.ts"));
+
+if (isDirectExecution) {
+  try {
+    main();
+  } catch (error) {
+    console.error(
+      `\n  [X] @ai-kit/core postinstall failed:`,
+      error instanceof Error ? error.message : String(error)
+    );
+    // Don't exit(1) — postinstall failures shouldn't block npm install
+  }
+}

--- a/src/preuninstall.ts
+++ b/src/preuninstall.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+/**
+ * @ai-kit/core preuninstall
+ *
+ * Removes symlinks created by postinstall.
+ * Only removes links that point to our kit directory — never touches user files.
+ */
+
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readlinkSync,
+  unlinkSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export const MARKER_FILE = ".ai-kit-npm";
+export const CHECKSUMS_FILE = ".ai-kit-checksums";
+
+export function getOpenCodeHome(): string {
+  return (
+    process.env.OPENCODE_HOME ?? join(homedir(), ".config", "opencode")
+  );
+}
+
+export function isOurSymlink(linkPath: string, kitDir: string): boolean {
+  try {
+    if (!lstatSync(linkPath).isSymbolicLink()) return false;
+    const target = readlinkSync(linkPath);
+    const resolved = resolve(dirname(linkPath), target);
+    return resolved.startsWith(kitDir);
+  } catch {
+    return false;
+  }
+}
+
+export interface MarkerData {
+  version: string;
+  kitDir: string;
+  installedAt: string;
+  items: string[];
+}
+
+export function readMarker(ocHome: string): MarkerData | null {
+  const markerPath = join(ocHome, MARKER_FILE);
+  if (!existsSync(markerPath)) return null;
+
+  try {
+    return JSON.parse(readFileSync(markerPath, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+export function main(): void {
+  const ocHome = getOpenCodeHome();
+
+  console.log(`\n@ai-kit/core preuninstall`);
+  console.log(`  target: ${ocHome}`);
+
+  const marker = readMarker(ocHome);
+  if (!marker) {
+    console.log(`  [!] No install marker found, nothing to clean up`);
+    return;
+  }
+
+  const kitDir = marker.kitDir;
+  let removed = 0;
+  let skipped = 0;
+
+  for (const item of marker.items) {
+    const linkPath = join(ocHome, item);
+
+    if (!existsSync(linkPath) && !lstatExistsSafe(linkPath)) {
+      continue;
+    }
+
+    if (isOurSymlink(linkPath, kitDir)) {
+      unlinkSync(linkPath);
+      console.log(`  [OK] Removed symlink: ${item}`);
+      removed++;
+    } else {
+      console.log(`  [!] Skipped ${item} (not our symlink, user file preserved)`);
+      skipped++;
+    }
+  }
+
+  // Clean up marker and checksums
+  const markerPath = join(ocHome, MARKER_FILE);
+  if (existsSync(markerPath)) unlinkSync(markerPath);
+
+  const checksumsPath = join(ocHome, CHECKSUMS_FILE);
+  if (existsSync(checksumsPath)) unlinkSync(checksumsPath);
+
+  console.log(
+    `\n  [OK] Cleanup complete: ${removed} removed, ${skipped} skipped (user files preserved)\n`
+  );
+}
+
+export function lstatExistsSafe(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Only auto-execute when run directly (not when imported for testing)
+const isDirectExecution =
+  typeof process !== "undefined" &&
+  process.argv[1] &&
+  (process.argv[1].endsWith("preuninstall.js") ||
+    process.argv[1].endsWith("preuninstall.ts"));
+
+if (isDirectExecution) {
+  try {
+    main();
+  } catch (error) {
+    console.error(
+      `\n  [X] @ai-kit/core preuninstall failed:`,
+      error instanceof Error ? error.message : String(error)
+    );
+  }
+}

--- a/tests/npm-distribution.test.ts
+++ b/tests/npm-distribution.test.ts
@@ -1,0 +1,696 @@
+/**
+ * Tests for @ai-kit/core npm distribution scripts.
+ *
+ * Covers postinstall (symlink creation, checksum tracking, personalisation safety)
+ * and preuninstall (symlink cleanup, marker-based scoping).
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir, readFile, rm, writeFile, symlink, readlink } from "node:fs/promises";
+import { existsSync, lstatSync, readlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  BACKUP_SUFFIX,
+  CHECKSUMS_FILE,
+  KIT_LINK_ITEMS,
+  MARKER_FILE,
+  backupUserFile,
+  computeChecksums,
+  detectUserModifications,
+  getOpenCodeHome,
+  isOurSymlink,
+  isSymlinkToKit,
+  readStoredChecksums,
+  safeCreateLink,
+  sha256,
+  walkFiles,
+  writeChecksums,
+  writeMarker,
+} from "../src/postinstall";
+
+import {
+  isOurSymlink as preuninstallIsOurSymlink,
+  readMarker,
+  lstatExistsSafe,
+  main as preuninstallMain,
+} from "../src/preuninstall";
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+let testRoot: string;
+let kitDir: string;
+let ocHome: string;
+
+function uniqueDir(): string {
+  return join(
+    tmpdir(),
+    `ai-kit-npm-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+}
+
+async function writeTestFile(path: string, content: string): Promise<void> {
+  await mkdir(join(path, "..").replace(/\/\.\.$/, ""), { recursive: true });
+  const dir = path.substring(0, path.lastIndexOf("/"));
+  if (dir) await mkdir(dir, { recursive: true });
+  await writeFile(path, content, "utf-8");
+}
+
+async function setupKitDir(): Promise<void> {
+  // Populate kit/ with representative files for each link item
+  await writeTestFile(join(kitDir, "opencode.json"), '{"version": "test"}');
+  await writeTestFile(join(kitDir, "AGENTS.md"), "# Agents\n");
+  await writeTestFile(join(kitDir, "agents", "implementer.md"), "# Implementer\n");
+  await writeTestFile(join(kitDir, "skills", "my-skill", "SKILL.md"), "# Skill\n");
+  await writeTestFile(join(kitDir, "protocols", "DELEGATION.md"), "# Delegation\n");
+  await writeTestFile(join(kitDir, "plugins", "updater.ts"), "export function init() {}\n");
+}
+
+// ─── lifecycle ──────────────────────────────────────────────────────────────
+
+beforeEach(async () => {
+  testRoot = uniqueDir();
+  kitDir = join(testRoot, "kit");
+  ocHome = join(testRoot, "opencode-home");
+  await mkdir(kitDir, { recursive: true });
+  await mkdir(ocHome, { recursive: true });
+  // Override env so getOpenCodeHome() returns our test dir
+  process.env.OPENCODE_HOME = ocHome;
+});
+
+afterEach(async () => {
+  await rm(testRoot, { recursive: true, force: true });
+  delete process.env.OPENCODE_HOME;
+});
+
+// ─── postinstall: sha256 ────────────────────────────────────────────────────
+
+describe("sha256", () => {
+  test("returns consistent hash for same content", async () => {
+    const file = join(testRoot, "hash-test.txt");
+    await writeTestFile(file, "hello world");
+    const h1 = sha256(file);
+    const h2 = sha256(file);
+    expect(h1).toBe(h2);
+    expect(h1).toHaveLength(64); // SHA-256 hex length
+  });
+
+  test("returns different hash for different content", async () => {
+    const f1 = join(testRoot, "a.txt");
+    const f2 = join(testRoot, "b.txt");
+    await writeTestFile(f1, "content-a");
+    await writeTestFile(f2, "content-b");
+    expect(sha256(f1)).not.toBe(sha256(f2));
+  });
+});
+
+// ─── postinstall: walkFiles ─────────────────────────────────────────────────
+
+describe("walkFiles", () => {
+  test("returns empty array for nonexistent path", () => {
+    expect(walkFiles(join(testRoot, "nope"))).toEqual([]);
+  });
+
+  test("returns single file when given a file path", async () => {
+    const file = join(testRoot, "single.txt");
+    await writeTestFile(file, "hi");
+    expect(walkFiles(file)).toEqual([file]);
+  });
+
+  test("recursively walks directory", async () => {
+    await setupKitDir();
+    const files = walkFiles(join(kitDir, "skills"));
+    expect(files.length).toBe(1);
+    expect(files[0]).toContain("SKILL.md");
+  });
+
+  test("finds files in nested directories", async () => {
+    await mkdir(join(testRoot, "deep", "a", "b"), { recursive: true });
+    await writeTestFile(join(testRoot, "deep", "root.txt"), "r");
+    await writeTestFile(join(testRoot, "deep", "a", "mid.txt"), "m");
+    await writeTestFile(join(testRoot, "deep", "a", "b", "leaf.txt"), "l");
+    const files = walkFiles(join(testRoot, "deep"));
+    expect(files.length).toBe(3);
+  });
+});
+
+// ─── postinstall: isSymlinkToKit ────────────────────────────────────────────
+
+describe("isSymlinkToKit", () => {
+  test("returns true for symlink pointing into kit dir", async () => {
+    await setupKitDir();
+    const link = join(testRoot, "test-link");
+    await symlink(join(kitDir, "opencode.json"), link);
+    expect(isSymlinkToKit(link, kitDir)).toBe(true);
+  });
+
+  test("returns false for symlink pointing elsewhere", async () => {
+    const otherFile = join(testRoot, "other.txt");
+    await writeTestFile(otherFile, "other");
+    const link = join(testRoot, "other-link");
+    await symlink(otherFile, link);
+    expect(isSymlinkToKit(link, kitDir)).toBe(false);
+  });
+
+  test("returns false for regular file", async () => {
+    const file = join(testRoot, "regular.txt");
+    await writeTestFile(file, "regular");
+    expect(isSymlinkToKit(file, kitDir)).toBe(false);
+  });
+
+  test("returns false for nonexistent path", () => {
+    expect(isSymlinkToKit(join(testRoot, "nope"), kitDir)).toBe(false);
+  });
+});
+
+// ─── postinstall: isOurSymlink ──────────────────────────────────────────────
+
+describe("isOurSymlink", () => {
+  test("returns true for symlink with ai-kit in target path", async () => {
+    // Create a file inside a path containing 'ai-kit'
+    const aiKitPath = join(testRoot, "node_modules", "@ai-kit", "core");
+    await mkdir(aiKitPath, { recursive: true });
+    const file = join(aiKitPath, "test.txt");
+    await writeTestFile(file, "test");
+    const link = join(testRoot, "our-link");
+    await symlink(file, link);
+    expect(isOurSymlink(link)).toBe(true);
+  });
+
+  test("returns false for symlink not pointing to ai-kit", async () => {
+    // Use a path outside testRoot that won't contain "ai-kit" in its path
+    const isolatedDir = join(tmpdir(), `isolated-test-${Date.now()}`);
+    await mkdir(join(isolatedDir, "random"), { recursive: true });
+    const otherFile = join(isolatedDir, "random", "file.txt");
+    await writeFile(otherFile, "random", "utf-8");
+    const link = join(isolatedDir, "foreign-link");
+    await symlink(otherFile, link);
+    try {
+      expect(isOurSymlink(link)).toBe(false);
+    } finally {
+      await rm(isolatedDir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns false for regular file", async () => {
+    const file = join(testRoot, "regular.txt");
+    await writeTestFile(file, "data");
+    expect(isOurSymlink(file)).toBe(false);
+  });
+});
+
+// ─── postinstall: computeChecksums ──────────────────────────────────────────
+
+describe("computeChecksums", () => {
+  test("computes checksums for all kit items", async () => {
+    await setupKitDir();
+    const checksums = computeChecksums(kitDir);
+    expect(Object.keys(checksums).length).toBeGreaterThan(0);
+    // Should have entries for each file
+    expect(checksums["opencode.json"]).toBeDefined();
+    expect(checksums["AGENTS.md"]).toBeDefined();
+    expect(checksums["agents/implementer.md"]).toBeDefined();
+    expect(checksums["skills/my-skill/SKILL.md"]).toBeDefined();
+  });
+
+  test("checksums are valid SHA-256 hex strings", async () => {
+    await setupKitDir();
+    const checksums = computeChecksums(kitDir);
+    for (const hash of Object.values(checksums)) {
+      expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  test("returns empty object for empty kit dir", () => {
+    const checksums = computeChecksums(kitDir);
+    expect(checksums).toEqual({});
+  });
+});
+
+// ─── postinstall: readStoredChecksums / writeChecksums ──────────────────────
+
+describe("readStoredChecksums / writeChecksums", () => {
+  test("round-trips checksums through write then read", () => {
+    const checksums = { "opencode.json": "abc123", "AGENTS.md": "def456" };
+    writeChecksums(ocHome, checksums);
+    const read = readStoredChecksums(ocHome);
+    expect(read).toEqual(checksums);
+  });
+
+  test("returns null when no checksums file exists", () => {
+    expect(readStoredChecksums(ocHome)).toBeNull();
+  });
+
+  test("returns null for corrupt checksums file", async () => {
+    await writeTestFile(join(ocHome, CHECKSUMS_FILE), "not json{{{");
+    expect(readStoredChecksums(ocHome)).toBeNull();
+  });
+});
+
+// ─── postinstall: detectUserModifications ───────────────────────────────────
+
+describe("detectUserModifications", () => {
+  test("detects modified regular files", async () => {
+    // Write a file in ocHome and record its checksum
+    const filePath = join(ocHome, "opencode.json");
+    await writeTestFile(filePath, '{"original": true}');
+    const originalHash = sha256(filePath);
+    const stored = { "opencode.json": originalHash };
+
+    // Modify the file
+    await writeFile(filePath, '{"modified": true}', "utf-8");
+
+    const modified = detectUserModifications(ocHome, stored);
+    expect(modified).toContain("opencode.json");
+  });
+
+  test("skips symlinks (not user files)", async () => {
+    await setupKitDir();
+    const link = join(ocHome, "opencode.json");
+    await symlink(join(kitDir, "opencode.json"), link);
+    const stored = { "opencode.json": "some-old-hash" };
+
+    const modified = detectUserModifications(ocHome, stored);
+    expect(modified).toEqual([]);
+  });
+
+  test("skips nonexistent files", () => {
+    const stored = { "missing.json": "abc123" };
+    const modified = detectUserModifications(ocHome, stored);
+    expect(modified).toEqual([]);
+  });
+
+  test("returns empty array when nothing modified", async () => {
+    const filePath = join(ocHome, "test.md");
+    await writeTestFile(filePath, "original content");
+    const hash = sha256(filePath);
+    const stored = { "test.md": hash };
+
+    const modified = detectUserModifications(ocHome, stored);
+    expect(modified).toEqual([]);
+  });
+});
+
+// ─── postinstall: backupUserFile ────────────────────────────────────────────
+
+describe("backupUserFile", () => {
+  test("renames file with backup suffix", async () => {
+    const file = join(testRoot, "user-file.json");
+    await writeTestFile(file, "user content");
+    backupUserFile(file);
+
+    expect(existsSync(file)).toBe(false);
+    expect(existsSync(file + BACKUP_SUFFIX)).toBe(true);
+
+    const backupContent = await readFile(file + BACKUP_SUFFIX, "utf-8");
+    expect(backupContent).toBe("user content");
+  });
+});
+
+// ─── postinstall: safeCreateLink ────────────────────────────────────────────
+
+describe("safeCreateLink", () => {
+  test("creates symlink for a file item", async () => {
+    await setupKitDir();
+    safeCreateLink(kitDir, ocHome, "opencode.json");
+
+    const link = join(ocHome, "opencode.json");
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    const target = readlinkSync(link);
+    expect(target).toBe(join(kitDir, "opencode.json"));
+  });
+
+  test("creates symlink for a directory item", async () => {
+    await setupKitDir();
+    safeCreateLink(kitDir, ocHome, "agents");
+
+    const link = join(ocHome, "agents");
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+  });
+
+  test("replaces existing symlink to our kit", async () => {
+    await setupKitDir();
+    // Create an initial symlink
+    const link = join(ocHome, "opencode.json");
+    const oldKit = join(testRoot, "old-ai-kit", "opencode.json");
+    await writeTestFile(oldKit, '{"old": true}');
+    await symlink(oldKit, link);
+
+    // safeCreateLink should replace it
+    safeCreateLink(kitDir, ocHome, "opencode.json");
+    const target = readlinkSync(link);
+    expect(target).toBe(join(kitDir, "opencode.json"));
+  });
+
+  test("backs up existing user file before linking", async () => {
+    await setupKitDir();
+    const userFile = join(ocHome, "opencode.json");
+    await writeTestFile(userFile, '{"user": true}');
+
+    safeCreateLink(kitDir, ocHome, "opencode.json");
+
+    // Symlink should exist
+    expect(lstatSync(userFile).isSymbolicLink()).toBe(true);
+    // User file should be backed up
+    expect(existsSync(userFile + BACKUP_SUFFIX)).toBe(true);
+    const backup = await readFile(userFile + BACKUP_SUFFIX, "utf-8");
+    expect(backup).toBe('{"user": true}');
+  });
+
+  test("skips missing kit items gracefully", async () => {
+    // Don't set up kit dir — item won't exist
+    safeCreateLink(kitDir, ocHome, "nonexistent-item");
+    expect(existsSync(join(ocHome, "nonexistent-item"))).toBe(false);
+  });
+});
+
+// ─── postinstall: writeMarker ───────────────────────────────────────────────
+
+describe("writeMarker", () => {
+  test("writes marker file with expected structure", async () => {
+    writeMarker(ocHome, kitDir);
+    const markerPath = join(ocHome, MARKER_FILE);
+    expect(existsSync(markerPath)).toBe(true);
+
+    const marker = JSON.parse(await readFile(markerPath, "utf-8"));
+    expect(marker.kitDir).toBe(kitDir);
+    expect(marker.installedAt).toBeDefined();
+    expect(marker.items).toEqual([...KIT_LINK_ITEMS]);
+  });
+});
+
+// ─── postinstall: getOpenCodeHome ───────────────────────────────────────────
+
+describe("getOpenCodeHome", () => {
+  test("returns OPENCODE_HOME env when set", () => {
+    process.env.OPENCODE_HOME = "/custom/path";
+    expect(getOpenCodeHome()).toBe("/custom/path");
+    process.env.OPENCODE_HOME = ocHome; // restore for other tests
+  });
+
+  test("falls back to ~/.config/opencode when env not set", () => {
+    const saved = process.env.OPENCODE_HOME;
+    delete process.env.OPENCODE_HOME;
+    const result = getOpenCodeHome();
+    expect(result).toContain(".config/opencode");
+    process.env.OPENCODE_HOME = saved;
+  });
+});
+
+// ─── postinstall: KIT_LINK_ITEMS ────────────────────────────────────────────
+
+describe("KIT_LINK_ITEMS", () => {
+  test("contains expected items", () => {
+    expect(KIT_LINK_ITEMS).toContain("opencode.json");
+    expect(KIT_LINK_ITEMS).toContain("AGENTS.md");
+    expect(KIT_LINK_ITEMS).toContain("agents");
+    expect(KIT_LINK_ITEMS).toContain("skills");
+    expect(KIT_LINK_ITEMS).toContain("protocols");
+    expect(KIT_LINK_ITEMS).toContain("plugins");
+    expect(KIT_LINK_ITEMS.length).toBe(6);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// preuninstall tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+// ─── preuninstall: readMarker ───────────────────────────────────────────────
+
+describe("readMarker", () => {
+  test("reads valid marker file", async () => {
+    const marker = {
+      version: "0.4.0",
+      kitDir,
+      installedAt: new Date().toISOString(),
+      items: ["opencode.json", "agents"],
+    };
+    await writeTestFile(
+      join(ocHome, MARKER_FILE),
+      JSON.stringify(marker, null, 2)
+    );
+
+    const result = readMarker(ocHome);
+    expect(result).not.toBeNull();
+    expect(result!.version).toBe("0.4.0");
+    expect(result!.kitDir).toBe(kitDir);
+    expect(result!.items).toEqual(["opencode.json", "agents"]);
+  });
+
+  test("returns null when marker doesn't exist", () => {
+    expect(readMarker(ocHome)).toBeNull();
+  });
+
+  test("returns null for corrupt marker", async () => {
+    await writeTestFile(join(ocHome, MARKER_FILE), "corrupt{{{");
+    expect(readMarker(ocHome)).toBeNull();
+  });
+});
+
+// ─── preuninstall: isOurSymlink (preuninstall version — uses kitDir) ────────
+
+describe("preuninstall isOurSymlink", () => {
+  test("returns true for symlink pointing into kitDir", async () => {
+    await setupKitDir();
+    const link = join(testRoot, "link-to-kit");
+    await symlink(join(kitDir, "opencode.json"), link);
+    expect(preuninstallIsOurSymlink(link, kitDir)).toBe(true);
+  });
+
+  test("returns false for symlink pointing elsewhere", async () => {
+    const other = join(testRoot, "other.txt");
+    await writeTestFile(other, "other");
+    const link = join(testRoot, "other-link");
+    await symlink(other, link);
+    expect(preuninstallIsOurSymlink(link, kitDir)).toBe(false);
+  });
+
+  test("returns false for regular file", async () => {
+    const file = join(testRoot, "file.txt");
+    await writeTestFile(file, "content");
+    expect(preuninstallIsOurSymlink(file, kitDir)).toBe(false);
+  });
+
+  test("returns false for nonexistent path", () => {
+    expect(preuninstallIsOurSymlink(join(testRoot, "nope"), kitDir)).toBe(false);
+  });
+});
+
+// ─── preuninstall: lstatExistsSafe ──────────────────────────────────────────
+
+describe("lstatExistsSafe", () => {
+  test("returns true for existing file", async () => {
+    const file = join(testRoot, "exists.txt");
+    await writeTestFile(file, "hi");
+    expect(lstatExistsSafe(file)).toBe(true);
+  });
+
+  test("returns true for existing symlink (even broken)", async () => {
+    const link = join(testRoot, "broken-link");
+    await symlink(join(testRoot, "nonexistent-target"), link);
+    // existsSync returns false for broken symlinks, but lstatExistsSafe should return true
+    expect(existsSync(link)).toBe(false);
+    expect(lstatExistsSafe(link)).toBe(true);
+  });
+
+  test("returns false for nonexistent path", () => {
+    expect(lstatExistsSafe(join(testRoot, "nope"))).toBe(false);
+  });
+});
+
+// ─── preuninstall: main (end-to-end) ────────────────────────────────────────
+
+describe("preuninstall main", () => {
+  test("removes our symlinks and cleans up marker/checksums", async () => {
+    await setupKitDir();
+
+    // Simulate a postinstall state: symlinks + marker + checksums
+    for (const item of KIT_LINK_ITEMS) {
+      const source = join(kitDir, item);
+      const target = join(ocHome, item);
+      if (existsSync(source)) {
+        await symlink(source, target);
+      }
+    }
+
+    // Write marker
+    const marker = {
+      version: "0.4.0",
+      kitDir,
+      installedAt: new Date().toISOString(),
+      items: [...KIT_LINK_ITEMS],
+    };
+    await writeTestFile(
+      join(ocHome, MARKER_FILE),
+      JSON.stringify(marker, null, 2)
+    );
+    await writeTestFile(
+      join(ocHome, CHECKSUMS_FILE),
+      JSON.stringify({ "opencode.json": "abc" })
+    );
+
+    // Run preuninstall
+    preuninstallMain();
+
+    // All symlinks should be gone
+    for (const item of KIT_LINK_ITEMS) {
+      const target = join(ocHome, item);
+      if (item === "opencode.json" || item === "AGENTS.md" || item === "agents" ||
+          item === "skills" || item === "protocols" || item === "plugins") {
+        expect(lstatExistsSafe(target)).toBe(false);
+      }
+    }
+
+    // Marker and checksums should be gone
+    expect(existsSync(join(ocHome, MARKER_FILE))).toBe(false);
+    expect(existsSync(join(ocHome, CHECKSUMS_FILE))).toBe(false);
+  });
+
+  test("preserves user files (non-symlinks)", async () => {
+    await setupKitDir();
+
+    // Create a user-owned file where a symlink would normally go
+    await writeTestFile(join(ocHome, "opencode.json"), '{"user": true}');
+
+    // Create symlinks for the rest
+    for (const item of KIT_LINK_ITEMS) {
+      if (item === "opencode.json") continue;
+      const source = join(kitDir, item);
+      const target = join(ocHome, item);
+      if (existsSync(source)) {
+        await symlink(source, target);
+      }
+    }
+
+    // Write marker with all items
+    const marker = {
+      version: "0.4.0",
+      kitDir,
+      installedAt: new Date().toISOString(),
+      items: [...KIT_LINK_ITEMS],
+    };
+    await writeTestFile(
+      join(ocHome, MARKER_FILE),
+      JSON.stringify(marker, null, 2)
+    );
+
+    preuninstallMain();
+
+    // User file should be preserved
+    expect(existsSync(join(ocHome, "opencode.json"))).toBe(true);
+    const content = await readFile(join(ocHome, "opencode.json"), "utf-8");
+    expect(content).toBe('{"user": true}');
+  });
+
+  test("handles missing marker gracefully (no-op)", () => {
+    // No marker file — should not throw
+    preuninstallMain();
+    // Nothing to assert beyond no-throw
+  });
+});
+
+// ─── end-to-end: postinstall → preuninstall cycle ───────────────────────────
+
+describe("postinstall → preuninstall cycle", () => {
+  test("full install then uninstall leaves clean state", async () => {
+    await setupKitDir();
+
+    // Simulate postinstall
+    for (const item of KIT_LINK_ITEMS) {
+      safeCreateLink(kitDir, ocHome, item);
+    }
+    const checksums = computeChecksums(kitDir);
+    writeChecksums(ocHome, checksums);
+    writeMarker(ocHome, kitDir);
+
+    // Verify install state
+    for (const item of KIT_LINK_ITEMS) {
+      const target = join(ocHome, item);
+      if (existsSync(join(kitDir, item))) {
+        expect(lstatSync(target).isSymbolicLink()).toBe(true);
+      }
+    }
+    expect(existsSync(join(ocHome, MARKER_FILE))).toBe(true);
+    expect(existsSync(join(ocHome, CHECKSUMS_FILE))).toBe(true);
+
+    // Run preuninstall
+    preuninstallMain();
+
+    // Verify clean state
+    for (const item of KIT_LINK_ITEMS) {
+      expect(lstatExistsSafe(join(ocHome, item))).toBe(false);
+    }
+    expect(existsSync(join(ocHome, MARKER_FILE))).toBe(false);
+    expect(existsSync(join(ocHome, CHECKSUMS_FILE))).toBe(false);
+  });
+
+  test("reinstall after uninstall works cleanly", async () => {
+    await setupKitDir();
+
+    // First install
+    for (const item of KIT_LINK_ITEMS) {
+      safeCreateLink(kitDir, ocHome, item);
+    }
+    writeChecksums(ocHome, computeChecksums(kitDir));
+    writeMarker(ocHome, kitDir);
+
+    // Uninstall
+    preuninstallMain();
+
+    // Second install
+    for (const item of KIT_LINK_ITEMS) {
+      safeCreateLink(kitDir, ocHome, item);
+    }
+    writeChecksums(ocHome, computeChecksums(kitDir));
+    writeMarker(ocHome, kitDir);
+
+    // Verify second install is valid
+    for (const item of KIT_LINK_ITEMS) {
+      const target = join(ocHome, item);
+      if (existsSync(join(kitDir, item))) {
+        expect(lstatSync(target).isSymbolicLink()).toBe(true);
+      }
+    }
+    expect(existsSync(join(ocHome, MARKER_FILE))).toBe(true);
+  });
+
+  test("update scenario: modified user file gets backed up on reinstall", async () => {
+    await setupKitDir();
+
+    // First install
+    for (const item of KIT_LINK_ITEMS) {
+      safeCreateLink(kitDir, ocHome, item);
+    }
+    const checksums = computeChecksums(kitDir);
+    writeChecksums(ocHome, checksums);
+    writeMarker(ocHome, kitDir);
+
+    // Simulate user modifying a file:
+    // Remove symlink, write a regular file
+    const ocJsonLink = join(ocHome, "opencode.json");
+    const { unlinkSync } = await import("node:fs");
+    unlinkSync(ocJsonLink);
+    await writeFile(ocJsonLink, '{"customised": true}', "utf-8");
+
+    // Detect modifications (like postinstall would on upgrade)
+    const stored = readStoredChecksums(ocHome);
+    expect(stored).not.toBeNull();
+    const modified = detectUserModifications(ocHome, stored!);
+    // opencode.json was a symlink before, now it's a regular file — but
+    // detectUserModifications only flags regular files with changed hashes.
+    // Since we replaced the symlink with a regular file, the hash will differ.
+    expect(modified).toContain("opencode.json");
+
+    // Reinstall: safeCreateLink should back up the user file
+    safeCreateLink(kitDir, ocHome, "opencode.json");
+
+    // User file backed up
+    expect(existsSync(ocJsonLink + BACKUP_SUFFIX)).toBe(true);
+    const backup = await readFile(ocJsonLink + BACKUP_SUFFIX, "utf-8");
+    expect(backup).toBe('{"customised": true}');
+
+    // Symlink restored
+    expect(lstatSync(ocJsonLink).isSymbolicLink()).toBe(true);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["plugins/**/*.ts", ".opencode/tools/**/*.ts", "tests/**/*.ts"]
+  "include": ["src/**/*.ts", "plugins/**/*.ts", ".opencode/tools/**/*.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

- Add `@ai-kit/core` npm package for distribution — `npm install --save-dev @ai-kit/core`
- **Postinstall** symlinks kit files (agents, skills, protocols, plugins, config) into `~/.config/opencode/`
- **Preuninstall** cleanly removes only our symlinks, preserving user files
- **Personalisation safety**: SHA-256 checksums detect user-modified files and back them up (`.user-backup` suffix) before replacing
- **Updater plugin**: detects npm-distributed mode via `.ai-kit-npm` marker, skips bash auto-updater
- **Build pipeline**: `build-kit` copies distributable files into `kit/` for npm packaging

## Files Changed

| File | Change |
|------|--------|
| `src/postinstall.ts` | NEW — symlink lifecycle with checksum safety |
| `src/preuninstall.ts` | NEW — clean uninstall, removes only our symlinks |
| `src/build-kit.ts` | NEW — copies distributable files into kit/ |
| `tests/npm-distribution.test.ts` | NEW — 49 tests, 110 assertions |
| `package.json` | Updated: name, scripts, files, postinstall/preuninstall hooks |
| `plugins/ai-kit-updater.ts` | Added npm-distributed detection |
| `tsconfig.json` | Added src/ to includes |
| `.gitignore` | Added dist/, kit/, .state/ |
| `README.md` | npm install instructions + personalisation safety docs |

## Testing

- **85 tests pass**, 0 failures, 184 assertions (full suite)
- `bunx tsc --noEmit` — clean
- `bun run build` — clean
- `bun run build-kit` — clean